### PR TITLE
fixed deprecated function call

### DIFF
--- a/AVCamSwift/ViewController.swift
+++ b/AVCamSwift/ViewController.swift
@@ -98,7 +98,7 @@ class ViewController: UIViewController, AVCaptureFileOutputRecordingDelegate {
                     // Because AVCaptureVideoPreviewLayer is the backing layer for AVCamPreviewView and UIView can only be manipulated on main thread.
                     // Note: As an exception to the above rule, it is not necessary to serialize video orientation changes on the AVCaptureVideoPreviewLayer’s connection with other session manipulation.
 
-                    let orientation: AVCaptureVideoOrientation =  AVCaptureVideoOrientation(rawValue: self.interfaceOrientation.rawValue)!
+                    let orientation: AVCaptureVideoOrientation =  AVCaptureVideoOrientation(rawValue: UIDevice.currentDevice().orientation.rawValue)!
                     
                     
                     (self.previewView.layer as! AVCaptureVideoPreviewLayer).connection.videoOrientation = orientation


### PR DESCRIPTION
Fixed a deprecated function (deprecated in iOS 8).

(I know there are a lot more Swift language adjustments to be made, but I did not want to do them right now - maybe at a later time)
